### PR TITLE
Prepare a Common object for custom chains

### DIFF
--- a/packages/hdwallet-provider/package.json
+++ b/packages/hdwallet-provider/package.json
@@ -26,6 +26,7 @@
     "bindings": "^1.5.0",
     "ethereum-cryptography": "^0.1.3",
     "ethereum-protocol": "^1.0.1",
+    "ethereumjs-common": "1.5.0",
     "ethereumjs-tx": "^2.1.2",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^1.0.1"


### PR DESCRIPTION
`ethereumjs-tx` does not recognize a custom chain ID, but will happily take a custom `Common` object. We prepare one if we detect a custom chain.

Currently it assumes that:
- All chains are on their latest hard fork
- The custom chain is based off of the latest hard fork of `mainnet`